### PR TITLE
feat: adds character rotation to the character creator menus

### DIFF
--- a/client/plugins/vmenu/ui.ts
+++ b/client/plugins/vmenu/ui.ts
@@ -12,7 +12,7 @@ import { applyVMenuCharacter, IVMenuCharacter } from './ped';
  * @param parentMenu 
  * @param store 
  */
-export function addvMenuCharacterList(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore) {
+export function addvMenuCharacterList(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore): Menu | undefined {
     const characters = getVMenuCharacters();
 
     if (characters && Object.keys(characters).length > 0) {
@@ -33,6 +33,8 @@ export function addvMenuCharacterList(menuPool: MenuPool, parentMenu: Menu, stor
             console.log(JSON.stringify(store.character));
             updateMenuItemValues(characters[charName], store.character);
         });
+
+        return submenu;
     }
 }
 

--- a/client/ui/index.ts
+++ b/client/ui/index.ts
@@ -44,6 +44,26 @@ export async function RunUI() {
     const mainMenu = NativeUI.CreateMenu('Appearance', '~HUD_COLOUR_FREEMODE~EDIT CHARACTER', 47.5, 47.5);;
     const creatorMainMenu = NativeUI.MenuPool.AddSubMenu(menuPool, mainMenu, 'Character Creator', 'Create a GTA Online character.', true, false);
 
+    const rotateLeftLabel = 'INPUT_CREATOR_ROTATE_LEFT_DISPLAYONLY';
+    const rotateRightLabel = 'INPUT_CREATOR_ROTATE_RIGHT_DISPLAYONLY';
+    NativeUI.Menu.AddInstructionButton(creatorMainMenu, GetControlInstructionalButton(2, 205, true), GetLabelText(rotateLeftLabel));
+    NativeUI.Menu.AddInstructionButton(creatorMainMenu, GetControlInstructionalButton(2, 206, true), GetLabelText(rotateRightLabel));
+
+    setTick(() => {
+        if (inputState.inCreator) {
+            const playerPed = PlayerPedId();
+            const controlScales = [[205, 300], [206, -300]] as const;
+            for (const [controlId, scale] of controlScales) {
+                if (IsControlPressed(2, controlId) || IsDisabledControlPressed(2, controlId)) {
+                    const speed = scale * GetFrameTime();
+                    const [rotX, rotY, rotZ] = GetEntityRotation(playerPed, 2);
+                    SetEntityRotation(playerPed, rotX, rotY, rotZ + speed, 2, false);
+                    SetPedDesiredHeading(playerPed, rotZ + speed);
+                }
+            }
+        }
+    });
+
     NativeUI.setEventListener(mainMenu, 'OnMenuChanged', (parent, menu) => {
         const blocked = !!GetConvar(BlockCharCreatorConvar, 'false').match(/"?true"?/i);
 

--- a/client/ui/index.ts
+++ b/client/ui/index.ts
@@ -12,6 +12,7 @@ import { addMenuGender, resetMenuGender } from './menus/gender';
 import { addMenuHeritage, resetMenuHeritage } from './menus/heritage';
 import { addSavedCharactersMenu, UISavedCharactersMenuContext } from './menus/saved-characters';
 import { Menu, MenuPool, NativeUI } from './native-ui-wrapper';
+import { addRotateButtonsToMenu } from './utils';
 export * from './native-ui-wrapper';
 
 export const UIContext = {
@@ -21,7 +22,6 @@ export const UIContext = {
 };
 
 export function addFinishButton(menuPool: MenuPool, parentMenu: Menu) {
-
     const finishButton = NativeUI.MenuPool.AddSubMenu(menuPool, parentMenu, 'Save & Continue', 'Ready to play?', true, false);
     const sureButton = NativeUI.CreateItem('Are you sure?', 'Press Enter to continue');
     NativeUI.Menu.AddItem(finishButton, sureButton);
@@ -44,10 +44,7 @@ export async function RunUI() {
     const mainMenu = NativeUI.CreateMenu('Appearance', '~HUD_COLOUR_FREEMODE~EDIT CHARACTER', 47.5, 47.5);;
     const creatorMainMenu = NativeUI.MenuPool.AddSubMenu(menuPool, mainMenu, 'Character Creator', 'Create a GTA Online character.', true, false);
 
-    const rotateLeftLabel = 'INPUT_CREATOR_ROTATE_LEFT_DISPLAYONLY';
-    const rotateRightLabel = 'INPUT_CREATOR_ROTATE_RIGHT_DISPLAYONLY';
-    NativeUI.Menu.AddInstructionButton(creatorMainMenu, GetControlInstructionalButton(2, 205, true), GetLabelText(rotateLeftLabel));
-    NativeUI.Menu.AddInstructionButton(creatorMainMenu, GetControlInstructionalButton(2, 206, true), GetLabelText(rotateRightLabel));
+    addRotateButtonsToMenu(creatorMainMenu);
 
     setTick(() => {
         if (inputState.inCreator) {
@@ -136,15 +133,19 @@ export async function RunUI() {
     });
 
     addMenuGender(creatorMainMenu, store);
-    addMenuHeritage(menuPool, creatorMainMenu, store);
-    addMenuFaceShape(menuPool, creatorMainMenu, store);
-    addMenuAppearance(menuPool, creatorMainMenu, store);
+    addRotateButtonsToMenu(addMenuHeritage(menuPool, creatorMainMenu, store));
+    addRotateButtonsToMenu(addMenuFaceShape(menuPool, creatorMainMenu, store));
+    addRotateButtonsToMenu(addMenuAppearance(menuPool, creatorMainMenu, store));
     // addMenuUpperBody(menuPool, creatorMainMenu, store);
-    addAdvancedApparelMenu(menuPool, creatorMainMenu, store);
-    await addMenuApparel(menuPool, creatorMainMenu, store);
-    addSavedCharactersMenu(menuPool, creatorMainMenu, 'menu');
+    addRotateButtonsToMenu(addAdvancedApparelMenu(menuPool, creatorMainMenu, store));
+    addRotateButtonsToMenu(await addMenuApparel(menuPool, creatorMainMenu, store));
+    addRotateButtonsToMenu(addSavedCharactersMenu(menuPool, creatorMainMenu, 'menu'));
     addSavedCharactersMenu(menuPool, mainMenu, 'menuQuick');
-    vMenuPlugin.ui.addvMenuCharacterList(menuPool, creatorMainMenu, store);
+    const charListMenu = vMenuPlugin.ui.addvMenuCharacterList(menuPool, creatorMainMenu, store);
+    if (typeof charListMenu !== 'undefined') {
+        addRotateButtonsToMenu(charListMenu);
+    }
+
     vMenuPlugin.ui.addvMenuCharacterList(menuPool, mainMenu, store);
     addFinishButton(menuPool, creatorMainMenu);
 

--- a/client/ui/menus/apparel.ts
+++ b/client/ui/menus/apparel.ts
@@ -3,9 +3,10 @@ import { ChangeComponents } from 'ped';
 import { CharacterStore } from 'state/character-store';
 import { clothingStore } from 'state/clothing-store';
 import { Menu, MenuPool, NativeUI } from 'ui';
+import { addRotateButtonsToMenu } from 'ui/utils';
 import { createClothingCategorySubmenu } from './apparel/clothing-category-menu';
 
-export async function addMenuApparel(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore) {
+export async function addMenuApparel(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore): Menu {
     const submenu = NativeUI.MenuPool.AddSubMenu(menuPool, parentMenu, 'Apparel', 'Select to change your Apparel.', true, true);
 
     const { character } = store;
@@ -38,6 +39,7 @@ export async function addMenuApparel(menuPool: MenuPool, parentMenu: Menu, store
                 const textLabel = `CSHOP_ITEM${value as number}` as const;
                 const labelText = DoesTextLabelExist(textLabel) ? GetLabelText(textLabel) : (value as string);
                 menus[textLabel] = NativeUI.MenuPool.AddSubMenu(menuPool, submenu, labelText, '', true, false);
+                addRotateButtonsToMenu(menus[textLabel]);
             }
 
             return menus;
@@ -92,4 +94,6 @@ export async function addMenuApparel(menuPool: MenuPool, parentMenu: Menu, store
         }
         */
     });
+
+    return submenu;
 }

--- a/client/ui/menus/apparel.ts
+++ b/client/ui/menus/apparel.ts
@@ -6,7 +6,7 @@ import { Menu, MenuPool, NativeUI } from 'ui';
 import { addRotateButtonsToMenu } from 'ui/utils';
 import { createClothingCategorySubmenu } from './apparel/clothing-category-menu';
 
-export async function addMenuApparel(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore): Menu {
+export async function addMenuApparel(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore): Promise<Menu> {
     const submenu = NativeUI.MenuPool.AddSubMenu(menuPool, parentMenu, 'Apparel', 'Select to change your Apparel.', true, true);
 
     const { character } = store;

--- a/client/ui/menus/apparel/advanced.ts
+++ b/client/ui/menus/apparel/advanced.ts
@@ -3,7 +3,7 @@ import { CharacterStore } from 'state/character-store';
 import { Menu, MenuPool, NativeUI } from 'ui';
 import { Logger } from 'utils/logger';
 
-export function addAdvancedApparelMenu(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore) {
+export function addAdvancedApparelMenu(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore): Menu {
     const submenu = NativeUI.MenuPool.AddSubMenu(menuPool, parentMenu, 'Advanced Apparel Options', 'Select to manually tweak character component slots.', true, true);
 
     const compNames = [
@@ -102,4 +102,6 @@ export function addAdvancedApparelMenu(menuPool: MenuPool, parentMenu: Menu, sto
             createLists(menu, compNames[menuIndex] as never);
         }
     });
+
+    return submenu;
 }

--- a/client/ui/menus/apparel/clothing-category-menu.ts
+++ b/client/ui/menus/apparel/clothing-category-menu.ts
@@ -6,6 +6,7 @@ import { Menu, MenuPool, NativeUI } from 'ui';
 import { iterateDrawables } from './stupid-drawable-index-fix';
 import { Outfit } from 'constants/outfit';
 import { Logger } from 'utils/logger';
+import { addRotateButtonsToMenu } from 'ui/utils';
 
 /**
  * Creates a submenu of clothing categories for a top-level category.
@@ -72,6 +73,8 @@ export function createClothingCategorySubmenu(menuPool: MenuPool, parentMenu: Me
                             menu: NativeUI.MenuPool.AddSubMenu(menuPool, parentMenu, labelText, '', true, true),
                             items: [] as typeof menus[typeof locateLabel]['items']
                         };
+
+                        addRotateButtonsToMenu(menus[locateLabel].menu);
 
                         // Add a "Force Apply" button in the bottom-right when this submenu is open.
                         NativeUI.Menu.AddInstructionButton(menus[locateLabel].menu, GetControlInstructionalButton(2, ForceApplyControlId, true), 'Force Apply');

--- a/client/ui/menus/appearance.ts
+++ b/client/ui/menus/appearance.ts
@@ -63,7 +63,7 @@ function hasOverlay(overlayValues: [number, number] | [number, number, number]):
 	return overlayValues.some((v) => v !== 0);
 }
 
-export function addMenuAppearance(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore) {
+export function addMenuAppearance(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore): Menu {
 	if (submenu) {
 		NativeUI.Menu.Clear(submenu);
 	} else {
@@ -584,6 +584,8 @@ export function addMenuAppearance(menuPool: MenuPool, parentMenu: Menu, store: C
 	submenu.OnMenuClosed = function()
 		CreateSkinCam('body')
 	end*/
+
+	return submenu;
 }
 
 export function resetMenuAppearance({ character }: Pick<CharacterStore, 'character'> = store) {

--- a/client/ui/menus/face-shape.ts
+++ b/client/ui/menus/face-shape.ts
@@ -31,7 +31,7 @@ export const FaceFeatureNameMap: ReadonlyArray<[name: string, featureName: keyof
 	['Neck Thickness', 'neck_thick']
 ];
 
-export function addMenuFaceShape(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore) {
+export function addMenuFaceShape(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore): Menu {
 	const listItems = new Array<string>();
 	for (let i = -1.0; i <= 1.0; i += 0.1) {
 		listItems.push(`${i.toFixed(1)}`);
@@ -75,6 +75,8 @@ export function addMenuFaceShape(menuPool: MenuPool, parentMenu: Menu, store: Ch
 		createSkinCamera(cameraShots.body);
 		// CreateSkinCam('body');
 	});
+
+	return submenu;
 }
 
 export function resetMenuFaceShape({ character }: Pick<CharacterStore, 'character'> = store) {

--- a/client/ui/menus/heritage.ts
+++ b/client/ui/menus/heritage.ts
@@ -20,7 +20,7 @@ export const UIHeritageMenuContext: Partial<IUIHeritageMenuContext> = {
 
 };
 
-export function addMenuHeritage(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore) {
+export function addMenuHeritage(menuPool: MenuPool, parentMenu: Menu, store: CharacterStore): Menu {
     const parents = [...Array<number>(46)].map((_, i) => `${i}`.padStart(2, '0'));
 
     const moms = FemaleParentIds;
@@ -126,6 +126,8 @@ export function addMenuHeritage(menuPool: MenuPool, parentMenu: Menu, store: Cha
         createSkinCamera(cameraShots.body);
         // CreateSkinCam('body')
     });
+
+    return submenu;
 }
 
 /**

--- a/client/ui/menus/saved-characters.ts
+++ b/client/ui/menus/saved-characters.ts
@@ -83,7 +83,7 @@ export const UISavedCharactersMenuContext: IUISavedCharactersMenuContext = {
     }
 };
 
-export function addSavedCharactersMenu(menuPool: MenuPool, parentMenu: Menu, menuIndex: Extract<keyof IUISavedCharactersMenuContext, 'menu' | 'menuQuick'>) {
+export function addSavedCharactersMenu(menuPool: MenuPool, parentMenu: Menu, menuIndex: Extract<keyof IUISavedCharactersMenuContext, 'menu' | 'menuQuick'>): Menu {
     const menu = NativeUI.MenuPool.AddSubMenu(menuPool, parentMenu, 'Saved Characters', 'Apply one of your saved character appearance presets.', false, false);
 
     UISavedCharactersMenuContext[menuIndex] = menu;

--- a/client/ui/utils.ts
+++ b/client/ui/utils.ts
@@ -1,0 +1,12 @@
+import { Menu, NativeUI } from "./native-ui-wrapper";
+
+/**
+ * Adds Rotate Left/Right instructional buttons to a menu.
+ * @param menu 
+ */
+export function addRotateButtonsToMenu(menu: Menu) {
+    const rotateLeftLabel = 'INPUT_CREATOR_ROTATE_LEFT_DISPLAYONLY';
+    const rotateRightLabel = 'INPUT_CREATOR_ROTATE_RIGHT_DISPLAYONLY';
+    NativeUI.Menu.AddInstructionButton(menu, GetControlInstructionalButton(2, 205, true), GetLabelText(rotateLeftLabel));
+    NativeUI.Menu.AddInstructionButton(menu, GetControlInstructionalButton(2, 206, true), GetLabelText(rotateRightLabel));
+}

--- a/client/ui/utils.ts
+++ b/client/ui/utils.ts
@@ -1,4 +1,4 @@
-import { Menu, NativeUI } from "./native-ui-wrapper";
+import { Menu, NativeUI } from './native-ui-wrapper';
 
 /**
  * Adds Rotate Left/Right instructional buttons to a menu.


### PR DESCRIPTION
This PR adds instructional buttons to the character creator menus that allow the player to rotate the ped right/left in order to preview them from any side.

![image](https://github.com/user-attachments/assets/0fa9cb7e-b326-43db-8cce-8093fcbf1c3c)


Closes #11